### PR TITLE
Update to v2.7.1

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,10 +4,10 @@
 #
 #   include alfred
 class alfred (
-  $version = '2.5.1_308'
+  $version = '2.7.1_387'
 ) {
   package { 'Alfred 2':
     provider => 'compressed_app',
-    source   => "http://cachefly.alfredapp.com/Alfred_${version}.zip"
+    source   => "https://cachefly.alfredapp.com/Alfred_${version}.zip"
   }
 }

--- a/spec/classes/alfred_spec.rb
+++ b/spec/classes/alfred_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'alfred' do
   it do
     should contain_package('Alfred 2').with({
-      :source   => 'http://cachefly.alfredapp.com/Alfred_2.5.1_308.zip',
+      :source   => 'https://cachefly.alfredapp.com/Alfred_2.7.1_387.zip',
       :provider => 'compressed_app'
     })
   end


### PR DESCRIPTION
the old URL `http://cachefly.alfredapp.com/Alfred_2.5.1_308.zip` returns a 404.